### PR TITLE
Fix password restrictions so they match local password requirements.

### DIFF
--- a/custom_components/sscpoe/config_flow.py
+++ b/custom_components/sscpoe/config_flow.py
@@ -54,7 +54,8 @@ class SSCPOE_ConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input:
             sn = user_input[CONF_ID]
             password = user_input[CONF_PASSWORD]
-            if len(password) != 6 or not password.isdigit():
+            pass_len = len(password)
+            if pass_len < 6 or pass_len > 12:
                 errors[CONF_PASSWORD] = "invalid_local_password"
             else:
 
@@ -141,7 +142,8 @@ class SSCPOE_ConfigFlow(ConfigFlow, domain=DOMAIN):
             email = user_input.get(CONF_EMAIL, None)
             password = user_input[CONF_PASSWORD]
             if sn:
-                if len(password) != 6 or not password.isdigit():
+                pass_len = len(password)
+                if pass_len < 6 or pass_len > 12:
                     errors[CONF_PASSWORD] = "invalid_local_password"
                 else:
 


### PR DESCRIPTION
The password restrictions for local access look the same as cloud access - between 6 and 12 characters.

This should fix: https://github.com/slydiman/sscpoe/issues/21

This is the login prompt locally:

<img width="364" height="363" alt="switch login" src="https://github.com/user-attachments/assets/1597053c-ec58-494b-a42b-638ea655b5f3" />

However, any 6–12 alphanumeric passwords are accepted. 

**Edit:** This is from the manual for the local web interface:

<img width="694" height="384" alt="switch manual" src="https://github.com/user-attachments/assets/3d133e25-5e16-486f-8cfa-1cefd75b220e" />

From: http://download.s21i.faimallusr.com/4336130/0/0/ABUIABA9GAAg55DTwwYooPiy1QQ.pdf?f=Cloud+Network+Management+Series+Web+Management+Manual%28Version+3%29+-2025.4.21.pdf&v=1752483943