### PR TITLE
Mcast src improve

### DIFF
--- a/custom_components/sscpoe/config_flow.py
+++ b/custom_components/sscpoe/config_flow.py
@@ -30,7 +30,7 @@ METHOD_LOCAL_WEB = "local_web"
 METHOD_LOCAL_MULTICAST = "local_multicast"
 
 CONF_BIND_INTERFACE = "bind_interface"
-CONF_SET_TTL = "set_ttl"
+#CONF_SET_TTL = "set_ttl"
 CONF_MCAST_TTL = "mcast_ttl"
 DEFAULT_BIND_INTERFACE = "default"
 
@@ -209,9 +209,9 @@ class SSCPOE_ConfigFlow(ConfigFlow, domain=DOMAIN):
     
         if user_input:
             bind_iface = str(user_input.get(CONF_BIND_INTERFACE, DEFAULT_BIND_INTERFACE))
-            set_ttl = bool(user_input.get(CONF_SET_TTL, False))
-            ttl = int(user_input.get(CONF_MCAST_TTL, ttl_default)) if set_ttl else None
-    
+            #set_ttl = bool(user_input.get(CONF_SET_TTL, False))
+            ttl = int(user_input.get(CONF_MCAST_TTL, ttl_default))
+
             bind_iface_param = None if bind_iface == DEFAULT_BIND_INTERFACE else bind_iface
     
             try:
@@ -229,19 +229,15 @@ class SSCPOE_ConfigFlow(ConfigFlow, domain=DOMAIN):
                     return await self.async_step_local_select()
     
             bind_default = bind_iface
-            set_ttl_default = set_ttl
-            if ttl is not None:
-                ttl_default = ttl
+            ttl_default = ttl
     
         schema_dict: dict = {
             vol.Required(CONF_BIND_INTERFACE, default=bind_default): vol.In(iface_choices),
-            vol.Required(CONF_SET_TTL, default=set_ttl_default): bool,
-        }
-        if set_ttl_default:
-            schema_dict[vol.Required(CONF_MCAST_TTL, default=ttl_default)] = vol.All(
+            vol.Optional(CONF_MCAST_TTL, default=ttl_default): vol.All(
                 vol.Coerce(int), vol.Range(min=1, max=255)
-            )
-    
+            ),
+        }   
+   
         return self.async_show_form(
             step_id="local_multicast",
             data_schema=vol.Schema(schema_dict),

--- a/custom_components/sscpoe/manifest.json
+++ b/custom_components/sscpoe/manifest.json
@@ -1,14 +1,14 @@
 {
   "domain": "sscpoe",
   "name": "SSCPOE",
-  "codeowners": ["@slydiman", "@DEvd"],
+  "codeowners": ["@slydiman"],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://gitverse.ru/DEvd/sscpoe-mdi",
+  "documentation": "https://github.com/slydiman/sscpoe",
   "homekit": {},
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://gitverse.ru/DEvd/sscpoe-mdi/issues",
+  "issue_tracker": "https://github.com/slydiman/sscpoe/issues",
   "requirements": ["requests"],
-  "version": "2025.12.14",
+  "version": "2025.12.08",
   "zeroconf": []
 }

--- a/custom_components/sscpoe/manifest.json
+++ b/custom_components/sscpoe/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/slydiman/sscpoe/issues",
   "requirements": ["requests"],
-  "version": "2025.12.08",
+  "version": "2025.12.16",
   "zeroconf": []
 }

--- a/custom_components/sscpoe/manifest.json
+++ b/custom_components/sscpoe/manifest.json
@@ -1,14 +1,14 @@
 {
   "domain": "sscpoe",
   "name": "SSCPOE",
-  "codeowners": ["@slydiman"],
+  "codeowners": ["@slydiman", "@DEvd"],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/slydiman/sscpoe",
+  "documentation": "https://gitverse.ru/DEvd/sscpoe-mdi",
   "homekit": {},
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/slydiman/sscpoe/issues",
+  "issue_tracker": "https://gitverse.ru/DEvd/sscpoe-mdi/issues",
   "requirements": ["requests"],
-  "version": "2025.12.08",
+  "version": "2025.12.14",
   "zeroconf": []
 }

--- a/custom_components/sscpoe/manifest.json
+++ b/custom_components/sscpoe/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/slydiman/sscpoe/issues",
   "requirements": ["requests"],
-  "version": "2025.12.16",
+  "version": "2025.12.17",
   "zeroconf": []
 }

--- a/custom_components/sscpoe/translations/en.json
+++ b/custom_components/sscpoe/translations/en.json
@@ -60,8 +60,7 @@
         "title": "Local discovery (Multicast)",
         "data": {
           "bind_interface": "Network interface",
-          "set_ttl": "Override multicast TTL",
-          "mcast_ttl": "Multicast TTL"
+          "mcast_ttl": "Multicast TTL value to override the default"
         }
       },
       "local_select": {

--- a/custom_components/sscpoe/translations/en.json
+++ b/custom_components/sscpoe/translations/en.json
@@ -1,46 +1,84 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "SSCPOE account is already configured",
-            "reauth_successful": "Reauthentication was successful"
-        },
-        "error": {
-            "invalid_email": "Invalid e-mail",
-            "invalid_ip": "Invalid IP address",
-            "invalid_web_password": "Password must be 6..12 chars",
-            "invalid_cloud_password": "Password must be 6..12 chars",
-            "invalid_local_password": "Password must be 6 digits",
-            "wrong_email": "E-mail not registered",
-            "wrong_password": "Incorrect password",
-            "cannot_connect": "Failed to connect",
-            "invalid_auth": "Invalid authentication",
-            "unknown": "unknown"
-        },
-        "step": {
-            "user": {
-                "title": "Select SSCPOE cloud, web or local (old API)"
-            },
-            "local": {
-                "title": "Fill in your SSCPOE credentials",
-                "data": {
-                    "id": "S/N",
-                    "password": "Password"
-                }
-            },
-            "cloud": {
-                "title": "Fill in your SSCPOE credentials",
-                "data": {
-                    "email": "E-mail",
-                    "password": "Password"
-                }
-            },
-            "reauth_confirm": {
-                "title": "Reauthenticate with your SSCPOE credentials",
-                "data": {
-                    "email": "E-mail",
-                    "password": "Password"
-                }
-            }
+  "config": {
+    "abort": {
+      "already_configured": "SSCPOE account is already configured",
+      "reauth_successful": "Reauthentication was successful",
+      "missing_entry": "Missing entry for re-authentication",
+      "unknown_action": "Unknown action"
+    },
+    "error": {
+      "invalid_email": "Invalid e-mail",
+      "invalid_ip": "Invalid IP address",
+      "invalid_web_password": "Password must be 6..12 chars",
+      "invalid_cloud_password": "Password must be 6..12 chars",
+      "invalid_local_password": "Password must be 6 digits",
+      "wrong_email": "E-mail not registered",
+      "wrong_password": "Incorrect password",
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "unknown",
+      "device_not_found": "Device not found in discovery results",
+      "multicast_discovery_failed": "Multicast discovery failed",
+      "multicast_discovery_timeout": "No devices found (timeout)"
+    },
+    "step": {
+      "user": {
+        "title": "Select SSCPOE cloud, web or local (old API)",
+        "data": {
+          "method": "Method"
         }
+      },
+      "local": {
+        "title": "Fill in your SSCPOE credentials",
+        "data": {
+          "id": "S/N",
+          "password": "Password"
+        }
+      },
+      "cloud": {
+        "title": "Fill in your SSCPOE credentials",
+        "data": {
+          "email": "E-mail",
+          "password": "Password"
+        }
+      },
+      "local_web": {
+        "title": "Local device (WEB)",
+        "data": {
+          "ip_address": "IP address",
+          "password": "Password"
+        }
+      },
+      "web": {
+        "title": "Local device (WEB)",
+        "data": {
+          "ip_address": "IP address",
+          "password": "Password"
+        }
+      },
+      "local_multicast": {
+        "title": "Local discovery (Multicast)",
+        "data": {
+          "bind_interface": "Network interface",
+          "set_ttl": "Override multicast TTL",
+          "mcast_ttl": "Multicast TTL"
+        }
+      },
+      "local_select": {
+        "title": "Select device",
+        "data": {
+          "action": "Device"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Reauthenticate with your SSCPOE credentials",
+        "data": {
+          "email": "E-mail",
+          "password": "Password",
+          "id": "S/N",
+          "ip_address": "IP address"
+        }
+      }
     }
+  }
 }

--- a/custom_components/sscpoe/translations/en.json
+++ b/custom_components/sscpoe/translations/en.json
@@ -4,6 +4,7 @@
       "already_configured": "SSCPOE account is already configured",
       "reauth_successful": "Reauthentication was successful",
       "missing_entry": "Missing entry for re-authentication",
+      "no_interfaces_with_ip": "No network interfaces with IP address found",
       "unknown_action": "Unknown action"
     },
     "error": {

--- a/custom_components/sscpoe/translations/ru.json
+++ b/custom_components/sscpoe/translations/ru.json
@@ -1,0 +1,84 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Аккаунт SSCPOE уже настроен",
+      "reauth_successful": "Повторная авторизация прошла успешно",
+      "missing_entry": "Не найдена запись для повторной авторизации",
+      "unknown_action": "Неизвестное действие"
+    },
+    "error": {
+      "invalid_email": "Некорректный e-mail",
+      "invalid_ip": "Некорректный IP-адрес",
+      "invalid_web_password": "Пароль должен быть длиной 6..12 символов",
+      "invalid_cloud_password": "Пароль должен быть длиной 6..12 символов",
+      "invalid_local_password": "Пароль должен быть длиной 6..12 символов",
+      "wrong_email": "E-mail не зарегистрирован",
+      "wrong_password": "Неверный пароль",
+      "cannot_connect": "Не удалось подключиться",
+      "invalid_auth": "Ошибка авторизации",
+      "unknown": "Неизвестная ошибка",
+      "device_not_found": "Устройство не найдено в результатах поиска",
+      "multicast_discovery_failed": "Ошибка multicast-поиска",
+      "multicast_discovery_timeout": "Устройства не найдены (таймаут)"
+    },
+    "step": {
+      "user": {
+        "title": "Выберите SSCPOE: облако, WEB или локально (старый API)",
+        "data": {
+          "method": "Способ"
+        }
+      },
+      "local": {
+        "title": "Введите данные SSCPOE",
+        "data": {
+          "id": "S/N",
+          "password": "Пароль"
+        }
+      },
+      "cloud": {
+        "title": "Введите данные SSCPOE",
+        "data": {
+          "email": "E-mail",
+          "password": "Пароль"
+        }
+      },
+      "local_web": {
+        "title": "Локальное устройство (WEB)",
+        "data": {
+          "ip_address": "IP-адрес",
+          "password": "Пароль"
+        }
+      },
+      "web": {
+        "title": "Локальное устройство (WEB)",
+        "data": {
+          "ip_address": "IP-адрес",
+          "password": "Пароль"
+        }
+      },
+      "local_multicast": {
+        "title": "Локальный поиск (Multicast)",
+        "data": {
+          "bind_interface": "Сетевой интерфейс",
+          "set_ttl": "Переопределить TTL multicast",
+          "mcast_ttl": "TTL multicast"
+        }
+      },
+      "local_select": {
+        "title": "Выбор устройства",
+        "data": {
+          "action": "Устройство"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Повторная авторизация SSCPOE",
+        "data": {
+          "email": "E-mail",
+          "password": "Пароль",
+          "id": "S/N",
+          "ip_address": "IP-адрес"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/sscpoe/translations/ru.json
+++ b/custom_components/sscpoe/translations/ru.json
@@ -4,6 +4,7 @@
       "already_configured": "Аккаунт SSCPOE уже настроен",
       "reauth_successful": "Повторная авторизация прошла успешно",
       "missing_entry": "Не найдена запись для повторной авторизации",
+      "no_interfaces_with_ip": "Не найдено сетевых интерфейсов с IP-адресом",
       "unknown_action": "Неизвестное действие"
     },
     "error": {

--- a/custom_components/sscpoe/translations/ru.json
+++ b/custom_components/sscpoe/translations/ru.json
@@ -60,7 +60,6 @@
         "title": "Локальный поиск (Multicast)",
         "data": {
           "bind_interface": "Сетевой интерфейс",
-          "set_ttl": "Переопределить TTL multicast",
           "mcast_ttl": "TTL multicast"
         }
       },


### PR DESCRIPTION
This patch reviews sscpoe device add and config procedure.
First of all, it adds explicit local multicast search setup with src interface and mcast ttl selection.
There are several UX patches as well.

### New "add record" flow 
the updated flow for SSCPOE integration is described below

The user chooses:
├── Cloud →flow left intact
├──Local(Web) → set IP+password → Web access verification → add Web/cancel 
└── Local(Multicast) → Interface refinement/ttl → do search +Web access verification → selector: old API(all devices found) or Web(those of found with web access granted) → add selected/cancel

#### "Local(Web)" steps
- Enter IP+ password
- Access verification(HTTP login attempt) 
- showing a list of items(one item max in this case): Add WEB GS108..., S/N: ...(IP) 
- creating an entry

#### "Local(Multicast)" steps
- Interface selection + mcast TTL edit 
- Device search 
- HTTP-Availability check(with default password) 
- Showing the list of items: 
    + Add old API GS108..., S/N: ...(IP)
    + Add WEB GS108..., S/N: ...(IP) ← if Web access is successful
- Creating an entry for selected item


#### Technical note
The logic of local_select\ is universal
- on the path from web local, it has a maximum of one element in the list, and with multicast local, there can be several elements.
- form the list of local_devices with the service field of the method of addition,
- add a duplicate device with the web method to multicast_local upon successful call to check_web_availability(copy the current element and replace the addition method from multicast/old to web)
- interpret the list in local_select only, taking into account the addition method for each element; minimum calculations: displaying the entire array piecemeal, and calling the corresponding handler element
